### PR TITLE
Change class name used for the passage wrapper

### DIFF
--- a/src/api/v1/functions/verse.ts
+++ b/src/api/v1/functions/verse.ts
@@ -30,7 +30,7 @@ export const getVerse = async (book: string, chapter: string, verses: string, ve
         if (unavailable) return { code: 400, message: "Verse not found" };
 
         const versesArray: Array<String> = [];
-        const wrapper = $(".text-19");
+        const wrapper = $(".text-17");
 
         await wrapper.each((i, p) => {
             let unformattedVerse = $(p).eq(0).text();


### PR DESCRIPTION
When I tried the script, it only show the `citation` column, without `passage`. Apparently Bible.com is now using the `text-text-light dark:text-text-dark text-17 md:text-19 leading-default md:leading-comfy font-aktiv-grotesk font-medium mbe-2` as class names. The only class name that looks viable to me at the moment is `text-17`.